### PR TITLE
Fix for Useless null check

### DIFF
--- a/src/main/java/tf/tuff/netty/ChunkHandler.java
+++ b/src/main/java/tf/tuff/netty/ChunkHandler.java
@@ -126,7 +126,7 @@ public class ChunkHandler extends ChannelOutboundHandlerAdapter {
         if (!viaReady && viaBlocks != null) {
             requestViaCache(chunkX, chunkZ, key);
         }
-        if (!y0Ready && y0 != null) {
+        if (!y0Ready) {
             requestY0Cache(chunkX, chunkZ, key);
         }
 


### PR DESCRIPTION
The correct fix is to remove the redundant null check from the conditional at line 129 while preserving behavior.

Best minimal change in `src/main/java/tf/tuff/netty/ChunkHandler.java`:
- Replace `if (!y0Ready && y0 != null) {` with `if (!y0Ready) {`.

Why this is safe:
- `!y0Ready` can only be true when `needY0` is true.
- `needY0` is true only when `y0 != null && y0.isPlayerReady(player)`.
- Therefore `y0` is already non-null whenever this branch executes.

No imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._