### PR TITLE
Fix for Useless null check

### DIFF
--- a/src/main/java/tf/tuff/netty/ChunkHandler.java
+++ b/src/main/java/tf/tuff/netty/ChunkHandler.java
@@ -123,7 +123,7 @@ public class ChunkHandler extends ChannelOutboundHandlerAdapter {
         q.y0Data = y0Data;
         queue.put(key, q);
 
-        if (!viaReady && viaBlocks != null) {
+        if (!viaReady) {
             requestViaCache(chunkX, chunkZ, key);
         }
         if (!y0Ready && y0 != null) {


### PR DESCRIPTION
To fix this cleanly without changing behavior, remove the redundant null check in the `if` guarding `requestViaCache`.  
Best minimal fix: change:

- `if (!viaReady && viaBlocks != null) { ... }`

to:

- `if (!viaReady) { ... }`

This preserves logic because `!viaReady` already guarantees `viaBlocks != null` based on how `viaReady` is computed.  
Edit only `src/main/java/tf/tuff/netty/ChunkHandler.java` in the `handleChunkPacket` method around lines 126–128. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._