### PR TITLE
Update PacketEvents dependency version to 2.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ repositories {
 dependencies {
     compileOnly 'org.spigotmc:spigot-api:1.18.2-R0.1-SNAPSHOT'
 
-    implementation 'com.github.retrooper:packetevents-spigot:2.11.1'
+    implementation 'com.github.retrooper:packetevents-spigot:2.12.1'
     
     compileOnly 'com.viaversion:viabackwards:5.3.2'
     compileOnly 'com.viaversion:viaversion:5.4.1'


### PR DESCRIPTION
Very simple fix, allows for tuffx-plus to work on spigot and paper on 26.1+, otherwise an error was given.
Tuffx already shifts down when choosing a mapping on an unsupported version, should be fine for beta.

https://github.com/retrooper/packetevents/releases/tag/v2.12.1
