### PR TITLE
Finalize folia support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ TuffX+ is a single, unified plugin that combines:
 
 ### Requirements
 - Java 17+
-- Spigot/Paper 1.18+
+- Spigot/Paper/Folia 1.18+
 - [ViaVersion](https://hangar.papermc.io/ViaVersion/ViaVersion) and [ViaBackwards](https://hangar.papermc.io/ViaVersion/ViaBackwards) (on the *backend* server *only*; not proxy)
 
 > PacketEvents, Jackson, and WebSocket libraries are shaded into the jar.

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ author: Potato
 authors: [Potato, SyntaxSavy, llucasandersen, coleis1op, UplandJacob]
 api-version: 1.18
 depend: [ViaVersion, ViaBackwards]
+folia-supported: true
 
 commands:
     viablocks:


### PR DESCRIPTION
Very simple, small PR to allow loading on Folia without manually having to edit the plugin.yml. Also documents Folia support in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit support for Folia servers.
  * Updated the supported server platforms to include Spigot, Paper, and Folia for version 1.18+.

* **Documentation**
  * Updated the installation requirements to reflect the expanded platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->